### PR TITLE
Fix problem with last_modified option

### DIFF
--- a/src/Illuminate/Http/Middleware/SetCacheHeaders.php
+++ b/src/Illuminate/Http/Middleware/SetCacheHeaders.php
@@ -3,6 +3,7 @@
 namespace Illuminate\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Carbon;
 
 class SetCacheHeaders
 {
@@ -32,6 +33,14 @@ class SetCacheHeaders
             $options['etag'] = md5($response->getContent());
         }
 
+        if (isset($options['last_modified'])) {
+            if (is_numeric($options['last_modified'])) {
+                $options['last_modified']=Carbon::createFromTimestamp($options['last_modified']);
+            }
+            else {
+                $options['last_modified']=Carbon::parse($options['last_modified']);						
+            }
+        }  
         $response->setCache($options);
         $response->isNotModified($request);
 


### PR DESCRIPTION
The SetCacheHeaders Middleware accept a parameter last_modified, the problem is that the middleware passes only strings as parameters and the setCache needs a DateTime compatible object. 

This fix parses the string passed in the last_modified option in two ways:

1) if the parameter is a number, a unix timestamp is assumed, parsed with Carbon and replaced in the options array
2) if the parameter is a string, it's send to the Carbon parse function in order to create a date and then is replaced in the options array

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
